### PR TITLE
Add a .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "pypy"
+script:
+  - python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+.. image:: https://secure.travis-ci.org/zbyte64/django-dockit.png?branch=master
+   :target: http://travis-ci.org/zbyte64/django-dockit
+
+
 Introduction
 ============
 


### PR DESCRIPTION
In order to enable Travis CI builds, in addition to accepting this pull request, you need to sign into Travis CI with your GitHub account and turn on Travis service hooks for your repo. See http://about.travis-ci.org/docs/user/getting-started/

The end result is that you can see your builds at http://travis-ci.org/zbyte64/django-dockit
