### PR TITLE
Fix test environment

### DIFF
--- a/test_environment/books/models.py
+++ b/test_environment/books/models.py
@@ -1,27 +1,29 @@
-import dockit
+from dockit.schema import Document, Schema, ModelReferenceField, \
+    TextField, DictField, SchemaField, FileField, IntegerField, \
+    ReferenceField, ListField, GenericSchemaField, CharField, DateField
 
 from django.contrib.auth.models import User
 
-class Author(dockit.Document):
-    user = dockit.ModelReferenceField(User)
-    internal_id = dockit.TextField()
+class Author(Document):
+    user = ModelReferenceField(User)
+    internal_id = TextField()
     
     class Meta:
         collection = 'author'
 
-class Address(dockit.Schema):
-    street_1 = dockit.TextField()
-    street_2 = dockit.TextField(blank=True)
-    city = dockit.TextField()
-    postal_code = dockit.TextField()
-    region = dockit.TextField()
-    country = dockit.TextField()
+class Address(Schema):
+    street_1 = TextField()
+    street_2 = TextField(blank=True)
+    city = TextField()
+    postal_code = TextField()
+    region = TextField()
+    country = TextField()
     
-    extra_data = dockit.DictField(blank=True)
+    extra_data = DictField(blank=True)
 
-class Publisher(dockit.Document):
-    name = dockit.TextField()
-    address = dockit.SchemaField(Address)
+class Publisher(Document):
+    name = TextField()
+    address = SchemaField(Address)
     
     def __unicode__(self):
         return self.name
@@ -29,34 +31,34 @@ class Publisher(dockit.Document):
     class Meta:
         collection = 'publisher'
 
-class Book(dockit.Document):
-    title = dockit.TextField()
-    cover_image = dockit.FileField(upload_to='book-images')
-    year = dockit.IntegerField()
-    publisher = dockit.ReferenceField(Publisher)
-    authors = dockit.ListField(dockit.ReferenceField(Author), db_index=True)
-    tags = dockit.ListField(dockit.TextField(), db_index=True)
+class Book(Document):
+    title = TextField()
+    cover_image = FileField(upload_to='book-images')
+    year = IntegerField()
+    publisher = ReferenceField(Publisher)
+    authors = ListField(ReferenceField(Author), db_index=True)
+    tags = ListField(TextField(), db_index=True)
     
     class Meta:
         collection = 'book'
 
 Book.objects.index('tags').commit()
 
-class SubComplexTwo(dockit.Schema):
-    field2 = dockit.TextField()
+class SubComplexTwo(Schema):
+    field2 = TextField()
 
-class SubComplexOne(dockit.Schema):
-    field1 = dockit.TextField()
-    nested = dockit.SchemaField(SubComplexTwo)
+class SubComplexOne(Schema):
+    field1 = TextField()
+    nested = SchemaField(SubComplexTwo)
 
-class ComplexObject(dockit.Document):
-    field1 = dockit.TextField()
-    image = dockit.FileField(upload_to='complex-images', blank=True)
-    addresses = dockit.ListField(dockit.SchemaField(Address), blank=True)
-    main_address = dockit.SchemaField(Address, blank=True)
-    generic_objects = dockit.ListField(dockit.GenericSchemaField(), blank=True)
+class ComplexObject(Document):
+    field1 = TextField()
+    image = FileField(upload_to='complex-images', blank=True)
+    addresses = ListField(SchemaField(Address), blank=True)
+    main_address = SchemaField(Address, blank=True)
+    generic_objects = ListField(GenericSchemaField(), blank=True)
     
-    nested = dockit.SchemaField(SubComplexOne, blank=True)
+    nested = SchemaField(SubComplexOne, blank=True)
     
     def __unicode__(self):
         return unicode(self.field1)
@@ -64,34 +66,34 @@ class ComplexObject(dockit.Document):
     class Meta:
         collection = 'complex_object'
 
-class Publication(dockit.Document):
-    name = dockit.CharField()
-    date = dockit.DateField()
+class Publication(Document):
+    name = CharField()
+    date = DateField()
     
     class Meta:
         typed_field = '_type'
 
 class Newspaper(Publication):
-    city = dockit.CharField()
+    city = CharField()
     
     class Meta:
         typed_key = 'newspaper'
 
 class Magazine(Publication):
-    issue_number = dockit.CharField()
+    issue_number = CharField()
     
     class Meta:
         typed_key = 'magazine'
 
-class BaseProduct(dockit.Document):
-    name = dockit.CharField()
+class BaseProduct(Document):
+    name = CharField()
     
     class Meta:
         typed_field = '_type'
 
-class Brand(dockit.Document):
-    name = dockit.CharField()
-    products = dockit.ListField(dockit.SchemaField(BaseProduct))
+class Brand(Document):
+    name = CharField()
+    products = ListField(SchemaField(BaseProduct))
 
 class Shoes(BaseProduct):
     class Meta:

--- a/test_environment/settings.py
+++ b/test_environment/settings.py
@@ -22,6 +22,16 @@ DATABASES = {
     }
 }
 
+DOCKIT_BACKENDS = {
+    'default': {'ENGINE':'dockit.backends.mongo.backend.MongoDocumentStorage',
+                'USER':'travis',
+                'PASSWORD':'test',
+                'DB':'mydb_test',
+                'HOST':'127.0.0.1',
+                'PORT':27017,}
+}
+
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.


### PR DESCRIPTION
These are changes that I had to make in order to be able to successfully run `python manage.py runserver` in the test_environment directory.

With these changes, I was able to add publishers and see them in MongoDB, but I got an error when trying to add a book (created issue #4 for this):

```
TypeError at /admin/books/book/add/
Error when calling the metaclass bases
    __init__() takes at least 2 arguments (4 given)

Traceback:
File "/Users/marca/dev/git-repos/django-dockit/django-dockit.venv/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  111.                         response = callback(request, *callback_args, **callback_kwargs)
File "/Users/marca/dev/git-repos/django-dockit/test_environment/dockit/admin/documentadmin.py" in wrapper
  386.                 return self.as_view(view, cacheable)(*args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/django-dockit.venv/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  93.                     response = view_func(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/django-dockit.venv/lib/python2.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
  79.         response = view_func(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/django-dockit.venv/lib/python2.7/site-packages/django/contrib/admin/sites.py" in inner
  197.             return view(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/django-dockit.venv/lib/python2.7/site-packages/django/views/generic/base.py" in view
  47.             return self.dispatch(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/test_environment/dockit/admin/views.py" in dispatch
  616.             return admin.get_create_view(object=self.object)(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/django-dockit.venv/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  93.                     response = view_func(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/django-dockit.venv/lib/python2.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
  79.         response = view_func(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/django-dockit.venv/lib/python2.7/site-packages/django/contrib/admin/sites.py" in inner
  197.             return view(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/django-dockit.venv/lib/python2.7/site-packages/django/views/generic/base.py" in view
  47.             return self.dispatch(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/test_environment/dockit/admin/views.py" in dispatch
  691.         return super(CreateView, self).dispatch(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/django-dockit.venv/lib/python2.7/site-packages/django/views/generic/base.py" in dispatch
  68.         return handler(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/test_environment/dockit/views/edit.py" in get
  75.         return super(BaseCreateView, self).get(request, *args, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/django-dockit.venv/lib/python2.7/site-packages/django/views/generic/edit.py" in get
  130.         form_class = self.get_form_class()
File "/Users/marca/dev/git-repos/django-dockit/test_environment/dockit/admin/views.py" in get_form_class
  202.             return self._generate_form_class()
File "/Users/marca/dev/git-repos/django-dockit/test_environment/dockit/admin/views.py" in _generate_form_class
  356.         class CustomDocumentForm(form_cls):
File "/Users/marca/dev/git-repos/django-dockit/test_environment/dockit/forms/forms.py" in __new__
  204.                                          opts.exclude, form_field_callback=opts.form_field_callback,)
File "/Users/marca/dev/git-repos/django-dockit/test_environment/dockit/forms/forms.py" in fields_for_document
  159.             field = form_field_callback(prop, type(field), **defaults)
File "/Users/marca/dev/git-repos/django-dockit/test_environment/dockit/admin/views.py" in formfield_for_field
  342.         return self.admin.formfield_for_field(prop, field, self, **kwargs)
File "/Users/marca/dev/git-repos/django-dockit/test_environment/dockit/admin/documentadmin.py" in formfield_for_field
  273.             subfield = self.formfield_for_field(prop, type(subfield_kwargs.pop('subfield')), view, **subfield_kwargs)
File "/Users/marca/dev/git-repos/django-dockit/test_environment/dockit/admin/documentadmin.py" in formfield_for_field
  280.         return field(**kwargs)

Exception Type: TypeError at /admin/books/book/add/
Exception Value: Error when calling the metaclass bases
    __init__() takes at least 2 arguments (4 given)
```
