### PR TITLE
Stop creation of `::memory::` file

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -14,7 +14,7 @@ MANAGERS = ADMINS
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': '::memory::',                      # Or path to database file if using sqlite3.
+        'NAME': '',                      # Or path to database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.
         'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.


### PR DESCRIPTION
Change sqlite database name from `'::memory::'` to `''` to prevent creation of zero-length `::memory::` file.
