### PR TITLE
Dockit doesn't work in Django < 1.4

### DIFF
--- a/dockit/templates/admin/schema_form.html
+++ b/dockit/templates/admin/schema_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_modify adminmedia staticfiles %}
+{% load i18n admin_modify adminmedia %}
 {% load url from future %}
 
 {% block extrahead %}{{ block.super }}
@@ -8,7 +8,7 @@
 {{ media }}
 {% endblock %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{{STATIC_URL}}admin/css/forms.css" />{% endblock %}
 
 {% block coltype %}{% if ordered_objects %}colMS{% else %}colM{% endif %}{% endblock %}
 


### PR DESCRIPTION
When you add a new application, it fails because the template wants to use the staticfiles template tags files, which are django 1.4 only.  This commit changes the static calls to STATIC_URL.

Thanks!
