### PR TITLE
Using static template tag fails in Django < 1.4

### DIFF
--- a/dockit/templates/admin/type_selection_form.html
+++ b/dockit/templates/admin/type_selection_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_modify adminmedia staticfiles %}
+{% load i18n admin_modify adminmedia %}
 {% load url from future %}
 
 {% block extrahead %}{{ block.super }}
@@ -8,7 +8,7 @@
 {{ media }}
 {% endblock %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}admin/css/forms.css" />{% endblock %}
 
 {% block coltype %}{% if ordered_objects %}colMS{% else %}colM{% endif %}{% endblock %}
 


### PR DESCRIPTION
This is the same as for the add application page, I switched the static tags out for STATIC_URL on the collections page.
