### PR TITLE
Unknown template library loaded when deleting collection

### DIFF
--- a/dockit/templates/admin/schema_delete_confirmation.html
+++ b/dockit/templates/admin/schema_delete_confirmation.html
@@ -1,7 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
 {% load url from future %}
-{% load admin_urls %}
 
 {% block breadcrumbs %}{% if not is_popup %}
 <div class="breadcrumbs">


### PR DESCRIPTION
I got an error when deleting a collection because an unknown tag library was loaded.  This patch allows the collection to be properly deleted.
